### PR TITLE
fix(specs): drop int type from nominal-only input specifications

### DIFF
--- a/exaflow/algorithms/exareme3/mixed_effects/glmm_binary.py
+++ b/exaflow/algorithms/exareme3/mixed_effects/glmm_binary.py
@@ -58,7 +58,7 @@ class GLMMBinary(Algorithm):
                 y=specs.InputDataSpecification(
                     label="Dependent variable (binary)",
                     desc="Nominal outcome converted using the positive class.",
-                    types=[specs.InputDataType.INT, specs.InputDataType.TEXT],
+                    types=[specs.InputDataType.TEXT],
                     stattypes=[specs.InputDataStatType.NOMINAL],
                     required=True,
                     max_count=1,

--- a/exaflow/algorithms/exareme3/model_selection/cross_validation/logistic_regression_cv.py
+++ b/exaflow/algorithms/exareme3/model_selection/cross_validation/logistic_regression_cv.py
@@ -107,7 +107,7 @@ class LogisticRegressionCV(Algorithm):
                 y=specs.InputDataSpecification(
                     label="Dependent variable (binary)",
                     desc="Nominal outcome converted using the positive class.",
-                    types=[specs.InputDataType.INT, specs.InputDataType.TEXT],
+                    types=[specs.InputDataType.TEXT],
                     stattypes=[specs.InputDataStatType.NOMINAL],
                     required=True,
                     max_count=1,

--- a/exaflow/algorithms/exareme3/naive_bayes/naive_bayes_categorical_cv.py
+++ b/exaflow/algorithms/exareme3/naive_bayes/naive_bayes_categorical_cv.py
@@ -54,7 +54,7 @@ class NaiveBayesCategorical(Algorithm):
                 y=specs.InputDataSpecification(
                     label="Variable (dependent)",
                     desc="A unique nominal variable.",
-                    types=[specs.InputDataType.TEXT, specs.InputDataType.INT],
+                    types=[specs.InputDataType.TEXT],
                     stattypes=[specs.InputDataStatType.NOMINAL],
                     required=True,
                     max_count=1,
@@ -62,7 +62,7 @@ class NaiveBayesCategorical(Algorithm):
                 x=specs.InputDataSpecification(
                     label="Covariates (independent)",
                     desc="One or more nominal variables.",
-                    types=[specs.InputDataType.TEXT, specs.InputDataType.INT],
+                    types=[specs.InputDataType.TEXT],
                     stattypes=[specs.InputDataStatType.NOMINAL],
                     required=True,
                 ),

--- a/exaflow/algorithms/exareme3/naive_bayes/naive_bayes_gaussian_cv.py
+++ b/exaflow/algorithms/exareme3/naive_bayes/naive_bayes_gaussian_cv.py
@@ -51,7 +51,7 @@ class NaiveBayesGaussianCV(Algorithm):
                 y=specs.InputDataSpecification(
                     label="Variable (dependent)",
                     desc="A unique nominal variable.",
-                    types=[specs.InputDataType.TEXT, specs.InputDataType.INT],
+                    types=[specs.InputDataType.TEXT],
                     stattypes=[specs.InputDataStatType.NOMINAL],
                     required=True,
                     max_count=1,

--- a/exaflow/algorithms/exareme3/statistics/histogram.py
+++ b/exaflow/algorithms/exareme3/statistics/histogram.py
@@ -61,7 +61,7 @@ class Histogram(Algorithm):
                 x=specs.InputDataSpecification(
                     label="Grouping variables",
                     desc="Optional categorical variables used to produce grouped histograms.",
-                    types=[specs.InputDataType.INT, specs.InputDataType.TEXT],
+                    types=[specs.InputDataType.TEXT],
                     stattypes=[specs.InputDataStatType.NOMINAL],
                     required=False,
                 ),


### PR DESCRIPTION
Nominal-only inputs should accept text, not integer storage types.