### PR TITLE
Enforce algorithm developer profile boundary

### DIFF
--- a/.agents/skills/exaflow-algorithm-scaffold/SKILL.md
+++ b/.agents/skills/exaflow-algorithm-scaffold/SKILL.md
@@ -19,6 +19,17 @@ Human-facing setup guide: `documentation/new-algorithm-setup.md`.
 1. Implement or update docs under `documentation/algorithms/` and `exaflow/algorithms/federated/docs/`.
 1. Run validation with `$exaflow-algorithm-validate` (fast, then strict when requested).
 
+## Algorithm Developer Profile
+
+Algorithm work may change algorithm-owned implementation, tests, fixtures, docs,
+and narrow registration/index files only. Do not modify controller, worker,
+aggregation server, protobuf, Kubernetes, config, dependency, privacy/security,
+API route, DTO, or orchestration code from an algorithm task.
+
+If an algorithm needs system-owned behavior, stop algorithm implementation and
+return a System Feature Request with the needed capability, current limitation,
+minimal requested system interface, algorithm-side impact, and evidence.
+
 ## Execution-First Contract
 
 Agents using this skill must keep working until the Definition of Done is met or a concrete blocker is proven by a failing command.
@@ -62,6 +73,7 @@ Definition of Done:
 - Standalone parity test exists and passes.
 - Prod validation test and non-empty expected fixture exist.
 - Registration touchpoints and docs are patched.
+- Algorithm profile boundary validation passes.
 - `validate_algorithms.py --new-algorithm <name>` passes with no warnings.
 - Focused standalone `pytest` passes. Ignore import order, formatting-only lint,
   and other purely mechanical style issues; automated tools handle them.

--- a/.agents/skills/exaflow-algorithm-validate/SKILL.md
+++ b/.agents/skills/exaflow-algorithm-validate/SKILL.md
@@ -18,6 +18,17 @@ Human-facing setup guide: `documentation/new-algorithm-setup.md`.
 1. Use `--strict` to run standalone + prod_env runtime suites.
 1. Inspect JSON output and resolve `failed` entries first, then `warn` entries.
 
+## Algorithm Developer Profile
+
+Algorithm work may change algorithm-owned implementation, tests, fixtures, docs,
+and narrow registration/index files only. Do not modify controller, worker,
+aggregation server, protobuf, Kubernetes, config, dependency, privacy/security,
+API route, DTO, or orchestration code from an algorithm task.
+
+If an algorithm needs system-owned behavior, stop algorithm implementation and
+return a System Feature Request with the needed capability, current limitation,
+minimal requested system interface, algorithm-side impact, and evidence.
+
 ## Execution-First Contract
 
 Agents using this skill must treat validator output as the source of truth. A task is not complete while `failed` or `warnings` are non-empty.
@@ -27,6 +38,7 @@ Definition of Done:
 - `validate_algorithms.py --new-algorithm <name>` exits successfully.
 - Validator JSON contains no `failed` entries.
 - Validator JSON contains no `warnings` entries.
+- Algorithm profile boundary validation passes.
 - New or changed algorithm contracts should not be backwards compatible by
   default. Treat legacy request shapes, aliases, fallback paths, deprecated
   output fields, compatibility shims, and silent normalization for old callers

--- a/.agents/skills/exaflow-algorithm-validate/scripts/validate_algorithms.py
+++ b/.agents/skills/exaflow-algorithm-validate/scripts/validate_algorithms.py
@@ -52,6 +52,39 @@ PREFERRED_DOC_PATHS = {
     "ttest_paired": "documentation/algorithms/TtestPaired.md",
 }
 
+ALGORITHM_PROFILE_SYSTEM_PREFIXES = (
+    "configs/",
+    "exadata-validator/",
+    "exaflow/aggregation_server/",
+    "exaflow/controller/",
+    "exaflow/protos/",
+    "exaflow/worker/",
+    "kubernetes/",
+)
+ALGORITHM_PROFILE_SYSTEM_FILES = {
+    ".deployment.sample.toml",
+    "pyproject.toml",
+    "run_analysis",
+    "tasks.py",
+    "uv.lock",
+}
+ALGORITHM_PROFILE_SHARED_FILES = {
+    "exaflow/algorithms/federated/README.md",
+    "exaflow/algorithms/federated/__init__.py",
+    "exaflow/algorithms/specifications.py",
+}
+ALGORITHM_PROFILE_SHARED_PATTERNS = (
+    re.compile(r"^exaflow/algorithms/federated/[a-z0-9_]+/__init__\.py$"),
+)
+ALGORITHM_PROFILE_ALLOWED_PATTERNS = (
+    re.compile(r"^documentation/algorithms/.+\.md$"),
+    re.compile(r"^exaflow/algorithms/exareme3/[a-z][a-z0-9_]*\.py$"),
+    re.compile(r"^exaflow/algorithms/federated/.+"),
+    re.compile(r"^tests/prod_env_tests/test_[a-z0-9_]+\.py$"),
+    re.compile(r"^tests/prod_env_tests/expected/[a-z0-9_]+_expected\.json$"),
+    re.compile(r"^tests/standalone_tests/federated_algorithms/.+"),
+)
+
 
 @dataclass
 class ReportEntry:
@@ -283,6 +316,81 @@ def map_changed_files_to_algorithms(changed_files: Iterable[str]) -> set[str]:
             break
 
     return algorithms
+
+
+def is_algorithm_profile_shared_path(changed_file: str) -> bool:
+    if changed_file in ALGORITHM_PROFILE_SHARED_FILES:
+        return True
+    return any(
+        pattern.match(changed_file)
+        for pattern in ALGORITHM_PROFILE_SHARED_PATTERNS
+    )
+
+
+def is_algorithm_profile_allowed_path(changed_file: str) -> bool:
+    if changed_file in ALGORITHM_PROFILE_SYSTEM_FILES:
+        return False
+    if changed_file.startswith(ALGORITHM_PROFILE_SYSTEM_PREFIXES):
+        return False
+    if changed_file.startswith("exaflow/algorithms/federated/docs/"):
+        return True
+    if is_algorithm_profile_shared_path(changed_file):
+        return True
+    return any(
+        pattern.match(changed_file)
+        for pattern in ALGORITHM_PROFILE_ALLOWED_PATTERNS
+    )
+
+
+def algorithm_profile_boundary_violations(changed_files: Iterable[str]) -> list[str]:
+    return sorted(
+        changed_file
+        for changed_file in changed_files
+        if not is_algorithm_profile_allowed_path(changed_file)
+    )
+
+
+def check_algorithm_profile_boundary(
+    report: list[ReportEntry],
+    *,
+    repo_root: Path,
+    changed_files: list[str],
+) -> None:
+    violations = algorithm_profile_boundary_violations(changed_files)
+
+    if not violations:
+        register(
+            report,
+            algorithm="*",
+            phase="static",
+            check="algorithm_profile_boundary",
+            status="pass",
+            severity="pass",
+            message="Changed files stay inside the algorithm developer profile.",
+            path=None,
+            repo_root=repo_root,
+        )
+        return
+
+    for rel in violations:
+        register(
+            report,
+            algorithm="*",
+            phase="static",
+            check="algorithm_profile_boundary",
+            status="failed",
+            severity="failed",
+            message=(
+                "Algorithm profile cannot change system-owned files: " f"{rel}"
+            ),
+            path=repo_root / rel,
+            repo_root=repo_root,
+            next_action=(
+                "Stop algorithm implementation and write a System Feature Request "
+                "covering the needed capability, current limitation, minimal "
+                "system interface, algorithm impact, and evidence."
+            ),
+        )
 
 
 def select_target_algorithms(
@@ -1547,6 +1655,12 @@ def main() -> int:
     check_touched_registration_files(
         report,
         algorithms=target_algorithms,
+        repo_root=repo_root,
+        changed_files=changed_files,
+    )
+
+    check_algorithm_profile_boundary(
+        report,
         repo_root=repo_root,
         changed_files=changed_files,
     )

--- a/.agents/skills/exaflow-algorithm-validate/scripts/validate_algorithms.py
+++ b/.agents/skills/exaflow-algorithm-validate/scripts/validate_algorithms.py
@@ -304,6 +304,8 @@ def map_changed_files_to_algorithms(changed_files: Iterable[str]) -> set[str]:
     ]
 
     for changed in changed_files:
+        if changed.endswith("_system_feature_request.md"):
+            continue
         if changed in reverse_docs:
             algorithms.add(reverse_docs[changed])
             continue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,42 @@ Do not run on your own:
 Use focused file reads, scoped searches, `--stat`, `-q`, and path-specific test
 commands instead.
 
+## Agent Profiles
+
+Algorithm work must run under the **Algorithm Developer Profile** unless the
+user explicitly asks for system/runtime changes. In this profile, agents may
+change algorithm-owned files only: Exareme3 wrappers, federated core logic,
+algorithm standalone tests, prod validation tests/fixtures, algorithm docs, and
+narrow algorithm registration/index files.
+
+Allowed narrow shared files are limited to algorithm exposure and metadata:
+`exaflow/algorithms/specifications.py`, federated `__init__.py` exports, and
+federated README/index entries. Do not use algorithm work to change controller,
+worker, aggregation server, protobuf, Kubernetes, config, dependency, privacy,
+security, API route, DTO, or orchestration code.
+
+If an algorithm cannot be implemented through existing algorithm interfaces, stop
+and write a System Feature Request instead of patching system-owned code:
+
+```text
+System feature needed for algorithm: <algorithm_id>
+
+Needed capability:
+<one sentence>
+
+Current limitation:
+<which existing API/spec/UDF/runtime behavior prevents implementation>
+
+Minimal requested system change:
+<interface or behavior requested, without implementation details unless obvious>
+
+Algorithm-side impact:
+<what can proceed now and what remains blocked>
+
+Evidence:
+<file/test/error references>
+```
+
 ## Architecture Rules
 
 See `documentation/context/architecture.md` and

--- a/documentation/algorithms/kmeans_cluster_creator_system_feature_request.md
+++ b/documentation/algorithms/kmeans_cluster_creator_system_feature_request.md
@@ -1,0 +1,23 @@
+# System Feature Request: K-means Cluster Creator
+
+System feature needed for algorithm: `kmeans_cluster_creator`
+
+Needed capability:
+Allow preprocessing steps to declare and receive runtime components, specifically an aggregation-server client, while transforming worker-local data before an algorithm runs.
+
+Current limitation:
+Current algorithm-owned interfaces allow an Exareme3 algorithm UDF to request the aggregation server with `@exareme3_udf(with_aggregation_server=True)`, but preprocessing steps do not currently make the controller choose an aggregation-server-backed execution strategy or pass an aggregation client into `transform_data_and_metadata`. A K-means cluster creator needs to fit cluster centers from aggregated sufficient statistics, then assign local rows to cluster labels during preprocessing. Without system support for aggregation-aware preprocessing, an algorithm developer would have to edit controller strategy selection and worker UDF preprocessing plumbing, which is outside the Algorithm Developer Profile.
+
+Minimal requested system change:
+Expose a supported preprocessing-step component contract so `PreprocessingStepSpecification.components` can affect execution strategy selection, and pass a scoped aggregation client to preprocessing transforms that declare they need it. The system behavior should preserve existing privacy checks, request cleanup, and worker-local row protection.
+
+Algorithm-side impact:
+Algorithm-owned work can define the preprocessing specification, K-means fitting logic, cluster-label metadata, documentation, and standalone tests once the runtime can provide aggregation during preprocessing. Until then, implementing `kmeans_cluster_creator` or a K-means-derived categorical variable variant is blocked because the required distributed fit cannot run inside the current preprocessing interface.
+
+Evidence:
+- Current K-means algorithm support uses an aggregation-server-backed UDF in `exaflow/algorithms/exareme3/cluster/kmeans.py`, which works for an algorithm result but does not create a transformed categorical column for downstream analyses.
+- The reference branch `k_means_enhancements` adds `exaflow/algorithms/exareme3/preprocessing/kmeans_cluster_creator.py`, which calls `transform_data_and_metadata(..., agg_client)` to fit K-means and create local cluster labels.
+- The same reference branch also changes system-owned files:
+  - `exaflow/controller/services/algorithm_execution_strategy_factory.py` to include preprocessing component requirements in strategy selection.
+  - `exaflow/worker/exareme3/udf/udf_service.py` to create an aggregation client when preprocessing requires it and to pass `agg_client` into preprocessing transforms.
+- Those controller and worker changes are not allowed under the Algorithm Developer Profile, so the algorithm variant should not be implemented in this guardrail exercise.

--- a/documentation/context/ai-task-templates.md
+++ b/documentation/context/ai-task-templates.md
@@ -189,10 +189,15 @@ Algorithm:
 
 Constraints:
 
+- Work under the Algorithm Developer Profile.
 - Use repository scaffold/validation skills for new algorithms.
 - Keep algorithm id consistent everywhere.
 - Prefer specification-level validation.
 - Do not leave placeholders.
+- Do not modify controller, worker, aggregation server, protobuf, Kubernetes,
+  config, dependency, privacy/security, API route, DTO, or orchestration code.
+- If system-owned code is required, stop and return a System Feature Request
+  instead of implementing that system change.
 
 Return:
 
@@ -200,6 +205,7 @@ Return:
 1. Files changed
 1. Validation skill output
 1. Tests run
+1. System Feature Request, if blocked by system-owned behavior
 1. Remaining risks
 
 ## Security-Sensitive Change Template

--- a/documentation/context/conventions.md
+++ b/documentation/context/conventions.md
@@ -35,6 +35,16 @@
   algorithm specifications exposed under `GET /specifications/*`.
 - `documentation/api-specification.md` documents the API contract for clients.
 
+### Agent Profiles
+
+- Algorithm development runs under the Algorithm Developer Profile: algorithm
+  wrappers, federated core logic, algorithm tests, fixtures, docs, and narrow
+  registration/index edits only.
+- Controller, worker, aggregation server, protobuf, Kubernetes, config,
+  dependency, privacy/security, API route, DTO, and orchestration changes are
+  system-owned and should be requested through a separate System Feature
+  Request when needed by an algorithm.
+
 ### Algorithms
 
 - Runtime Exareme3 algorithm wrappers live under

--- a/documentation/new-algorithm-setup.md
+++ b/documentation/new-algorithm-setup.md
@@ -121,6 +121,40 @@ The scaffold also patches common integration touchpoints when enabled:
 If the validator reports a missing symbol in one of those files, either rerun
 the scaffold with registration enabled or patch the reported file manually.
 
+## Algorithm Developer Profile
+
+Algorithm tasks are intentionally scoped to algorithm-owned files and narrow
+registration/index updates. Do not change controller, worker, aggregation server,
+protobuf, Kubernetes, config, dependency, privacy/security, API route, DTO, or
+runtime orchestration code while implementing an algorithm.
+
+If the algorithm needs a system capability that current algorithm interfaces do
+not provide, stop and create a system feature request instead of patching the
+system code from the algorithm task:
+
+```text
+System feature needed for algorithm: <algorithm_id>
+
+Needed capability:
+<one sentence>
+
+Current limitation:
+<which existing API/spec/UDF/runtime behavior prevents implementation>
+
+Minimal requested system change:
+<interface or behavior requested, without implementation details unless obvious>
+
+Algorithm-side impact:
+<what can proceed now and what remains blocked>
+
+Evidence:
+<file/test/error references>
+```
+
+The algorithm validator enforces this profile against changed and untracked
+files. Boundary failures mean the algorithm task is blocked until the system
+feature is handled separately.
+
 ## Family Defaults
 
 | Family | Use when | Command option |

--- a/tests/standalone_tests/test_algorithm_integration_driver.py
+++ b/tests/standalone_tests/test_algorithm_integration_driver.py
@@ -259,3 +259,11 @@ def test_validator_reports_algorithm_profile_boundary_failure(tmp_path):
     assert len(failed) == 1
     assert failed[0]["check"] == "algorithm_profile_boundary"
     assert "System Feature Request" in failed[0]["next_action"]
+
+
+def test_validator_ignores_system_feature_request_docs_as_algorithm_targets():
+    algorithms = VALIDATOR.map_changed_files_to_algorithms(
+        ["documentation/algorithms/kmeans_cluster_creator_system_feature_request.md"]
+    )
+
+    assert algorithms == set()

--- a/tests/standalone_tests/test_algorithm_integration_driver.py
+++ b/tests/standalone_tests/test_algorithm_integration_driver.py
@@ -200,3 +200,62 @@ def test_validator_fails_fixture_with_replacement_placeholders(tmp_path):
     ]
     assert placeholder_rows
     assert placeholder_rows[0]["severity"] == "failed"
+
+
+def test_validator_algorithm_profile_allows_algorithm_and_registration_paths():
+    changed_files = [
+        "exaflow/algorithms/exareme3/example_test.py",
+        "exaflow/algorithms/federated/statistics/example_test.py",
+        "exaflow/algorithms/federated/statistics/__init__.py",
+        "exaflow/algorithms/federated/__init__.py",
+        "exaflow/algorithms/federated/README.md",
+        "exaflow/algorithms/specifications.py",
+        "tests/standalone_tests/federated_algorithms/statistics/test_example_test.py",
+        "tests/prod_env_tests/test_example_test.py",
+        "tests/prod_env_tests/expected/example_test_expected.json",
+        "documentation/algorithms/example_test.md",
+    ]
+
+    violations = VALIDATOR.algorithm_profile_boundary_violations(changed_files)
+
+    assert violations == []
+
+
+def test_validator_algorithm_profile_blocks_system_owned_paths():
+    changed_files = [
+        "exaflow/algorithms/exareme3/example_test.py",
+        "exaflow/controller/quart/endpoints.py",
+        "exaflow/worker/grpc_server.py",
+        "exaflow/protos/worker/worker.proto",
+        "kubernetes/values.yaml",
+        "pyproject.toml",
+    ]
+
+    violations = VALIDATOR.algorithm_profile_boundary_violations(changed_files)
+
+    assert violations == [
+        "exaflow/controller/quart/endpoints.py",
+        "exaflow/protos/worker/worker.proto",
+        "exaflow/worker/grpc_server.py",
+        "kubernetes/values.yaml",
+        "pyproject.toml",
+    ]
+
+
+def test_validator_reports_algorithm_profile_boundary_failure(tmp_path):
+    report = []
+
+    VALIDATOR.check_algorithm_profile_boundary(
+        report,
+        repo_root=tmp_path,
+        changed_files=[
+            "exaflow/algorithms/exareme3/example_test.py",
+            "exaflow/controller/services/api/algorithm_request_dtos.py",
+        ],
+    )
+
+    rows = [entry.to_dict() for entry in report]
+    failed = [row for row in rows if row["severity"] == "failed"]
+    assert len(failed) == 1
+    assert failed[0]["check"] == "algorithm_profile_boundary"
+    assert "System Feature Request" in failed[0]["next_action"]


### PR DESCRIPTION
## Summary

- Adds an Algorithm Developer Profile boundary to repo docs, algorithm skills, and task templates.
- Enforces the boundary in the algorithm validator by failing algorithm validation when changed files include system-owned paths.
- Documents the K-means cluster creator guardrail exercise as a system feature request instead of patching controller/worker runtime code.

## Validation

- `python3 -B -m py_compile .agents/skills/exaflow-algorithm-validate/scripts/validate_algorithms.py`
- `uv run pytest -q tests/standalone_tests/test_algorithm_integration_driver.py` (`10 passed`)
- `python3 -B .agents/skills/exaflow-algorithm-validate/scripts/validate_algorithms.py --repo-root .` (no targets, no failures)
